### PR TITLE
Feature/issue 6

### DIFF
--- a/src/main/java/com/example/wegobe/WegoBeApplication.java
+++ b/src/main/java/com/example/wegobe/WegoBeApplication.java
@@ -1,13 +1,21 @@
 package com.example.wegobe;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.util.TimeZone;
+
+@EnableJpaAuditing
 @SpringBootApplication
 public class WegoBeApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(WegoBeApplication.class, args);
     }
-
+    @PostConstruct
+    public void setTime() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/main/java/com/example/wegobe/config/SecurityUtil.java
+++ b/src/main/java/com/example/wegobe/config/SecurityUtil.java
@@ -1,0 +1,19 @@
+package com.example.wegobe.config;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityUtil {
+
+    /**
+     * 현재 로그인한 사용자의 kakaoId 가져오기
+     */
+    public static Long getCurrentKakaoId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new RuntimeException("인증 정보가 없습니다.");
+        }
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
@@ -4,6 +4,7 @@ import com.example.wegobe.gathering.dto.request.GatheringRequestDto;
 import com.example.wegobe.gathering.dto.response.GatheringListResponseDto;
 import com.example.wegobe.gathering.dto.response.GatheringResponseDto;
 import com.example.wegobe.gathering.service.GatheringService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,8 +26,8 @@ public class GatheringController {
         return ResponseEntity.ok(id);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<GatheringResponseDto> getGathering(@PathVariable Long id) {
+    @GetMapping("/{gatheringId}")
+    public ResponseEntity<GatheringResponseDto> getGathering(@PathVariable("gatheringId") Long id) {
         GatheringResponseDto response = gatheringService.getGatheringById(id);
         return ResponseEntity.ok(response);
     }
@@ -36,4 +37,19 @@ public class GatheringController {
         return ResponseEntity.ok(gatheringService.findAll(pageable));
     }
 
+    @PatchMapping("/{gatheringId}")
+    public ResponseEntity<GatheringResponseDto> updateGathering(
+            @PathVariable("gatheringId") Long id,
+            @Valid @RequestBody  GatheringRequestDto updateDto) {
+
+        // 동행 수정 후 수정된 동행 정보 반환
+        GatheringResponseDto responseDto = gatheringService.updateGathering(id, updateDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
+    @DeleteMapping("/{gatheringId}")
+    public ResponseEntity<Void> deleteGathering(@PathVariable("gatheringId") Long id) {
+        gatheringService.deleteGathering(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
@@ -1,8 +1,14 @@
 package com.example.wegobe.gathering.controller;
 
 import com.example.wegobe.gathering.dto.request.GatheringRequestDto;
+import com.example.wegobe.gathering.dto.response.GatheringListResponseDto;
+import com.example.wegobe.gathering.dto.response.GatheringResponseDto;
 import com.example.wegobe.gathering.service.GatheringService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +23,17 @@ public class GatheringController {
     public ResponseEntity<Long> createGathering(@RequestBody GatheringRequestDto request) {
         Long id = gatheringService.createGathering(request);
         return ResponseEntity.ok(id);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<GatheringResponseDto> getGathering(@PathVariable Long id) {
+        GatheringResponseDto response = gatheringService.getGatheringById(id);
+        return ResponseEntity.ok(response);
+    }
+    @GetMapping("/list")
+    public ResponseEntity<Page<GatheringListResponseDto>> getGatheringList(
+            @PageableDefault(page = 0, size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(gatheringService.findAll(pageable));
     }
 
 }

--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringController.java
@@ -1,0 +1,22 @@
+package com.example.wegobe.gathering.controller;
+
+import com.example.wegobe.gathering.dto.request.GatheringRequestDto;
+import com.example.wegobe.gathering.service.GatheringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/gatherings")
+@RequiredArgsConstructor
+public class GatheringController {
+    private final GatheringService gatheringService;
+
+    @PostMapping
+    public ResponseEntity<Long> createGathering(@RequestBody GatheringRequestDto request) {
+        Long id = gatheringService.createGathering(request);
+        return ResponseEntity.ok(id);
+    }
+
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/Gathering.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/Gathering.java
@@ -77,4 +77,23 @@ public class Gathering extends BaseTimeEntity {
         this.hashtags = hashtags;
         this.creator = creator;
     }
+
+    public void update(
+            String title, String content, String location, String thumbnailUrl, int maxParticipants,
+            LocalDate startAt, LocalDate endAt, LocalDateTime closedAt, Gender preferredGender,
+            AgeGroup preferredAge, Category category) {
+
+        this.title = title;
+        this.content = content;
+        this.location = location;
+        this.thumbnailUrl = thumbnailUrl;
+        this.maxParticipants = maxParticipants;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.closedAt = closedAt;
+        this.preferredGender = preferredGender;
+        this.preferredAge = preferredAge;
+        this.category = category;
+
+    }
 }

--- a/src/main/java/com/example/wegobe/gathering/domain/Gathering.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/Gathering.java
@@ -1,0 +1,80 @@
+package com.example.wegobe.gathering.domain;
+
+import com.example.wegobe.auth.entity.User;
+import com.example.wegobe.gathering.domain.enums.AgeGroup;
+import com.example.wegobe.gathering.domain.enums.Category;
+import com.example.wegobe.gathering.domain.enums.Gender;
+import com.example.wegobe.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Gathering extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "gathering_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private String thumbnailUrl;
+
+    private Integer maxParticipants;    // 최대 인원
+
+    private LocalDate startAt;          // 동행 시작 날짜 (년월일시간분)
+
+    private LocalDate endAt;
+
+    private LocalDateTime closedAt;     // 모임 모집 마감날짜
+
+    private String location;            // 도로명주소
+
+    @Enumerated(EnumType.STRING)
+    private Gender preferredGender;
+
+    @Enumerated(EnumType.STRING)
+    private AgeGroup preferredAge;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "gathering_id")
+    private List<HashTag> hashtags = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User creator; // 주최자
+
+    @Builder
+    public Gathering(String title, String content, String location, String thumbnailUrl, int maxParticipants,
+                     LocalDate startAt, LocalDate endAt, LocalDateTime closedAt, Gender preferredGender,
+                     AgeGroup preferredAge, Category category, List<HashTag> hashtags, User creator) {
+        this.title = title;
+        this.content = content;
+        this.location = location;
+        this.thumbnailUrl = thumbnailUrl;
+        this.maxParticipants = maxParticipants;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.closedAt = closedAt;
+        this.preferredGender = preferredGender;
+        this.preferredAge = preferredAge;
+        this.category = category;
+        this.hashtags = hashtags;
+        this.creator = creator;
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/HashTag.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/HashTag.java
@@ -1,0 +1,29 @@
+package com.example.wegobe.gathering.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="gathering_id")
+    private Gathering gathering;
+
+    @Builder
+    public HashTag(String tag, Gathering gathering) {
+        this.tag = tag;
+        this.gathering = gathering;
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/enums/AgeGroup.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/enums/AgeGroup.java
@@ -1,0 +1,21 @@
+package com.example.wegobe.gathering.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AgeGroup {
+    ALL("나이무관",0,100),
+    TEENS("10대", 10, 19),
+    TWENTIES("20대", 20, 29),
+    THIRTIES("30대", 30, 39),
+    FORTIES("40대", 40, 49),
+    FIFTIES("50대", 50, 59),
+    SIXTIES("60대",60, 69),
+    SEVENTIES("70대",70,79);
+
+    private final String description;
+    private final int minAge;
+    private final int maxAge;
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/enums/Category.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/enums/Category.java
@@ -1,0 +1,16 @@
+package com.example.wegobe.gathering.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    PART("부분동행"),
+    TOUR("투어 동행"),
+    SHARE("숙박 공유"),
+    SHOW("전시/공연 동행"),
+    RESTAURANT("맛집 동행");
+
+    private final String description;
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/enums/Gender.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/enums/Gender.java
@@ -1,0 +1,14 @@
+package com.example.wegobe.gathering.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("남자"),
+    FEMALE("여자"),
+    ANY("남녀무관");
+
+    private final String description;
+}

--- a/src/main/java/com/example/wegobe/gathering/dto/request/GatheringRequestDto.java
+++ b/src/main/java/com/example/wegobe/gathering/dto/request/GatheringRequestDto.java
@@ -1,0 +1,41 @@
+package com.example.wegobe.gathering.dto.request;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.example.wegobe.gathering.domain.enums.AgeGroup;
+import com.example.wegobe.gathering.domain.enums.Category;
+import com.example.wegobe.gathering.domain.enums.Gender;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GatheringRequestDto {
+
+    private String title;
+    private String content;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+    private LocalDateTime closedAt;
+
+    private String thumbnailUrl;
+
+    private String address;
+
+    private int maxParticipants;
+
+    private Gender preferredGender;
+    private AgeGroup preferredAgeGroup;
+    private Category category;
+
+    private List<String> hashtags;
+}

--- a/src/main/java/com/example/wegobe/gathering/dto/response/GatheringListResponseDto.java
+++ b/src/main/java/com/example/wegobe/gathering/dto/response/GatheringListResponseDto.java
@@ -1,0 +1,63 @@
+package com.example.wegobe.gathering.dto.response;
+
+import com.example.wegobe.auth.dto.response.UserInfoResponseDto;
+import com.example.wegobe.gathering.domain.enums.AgeGroup;
+import com.example.wegobe.gathering.domain.enums.Category;
+import com.example.wegobe.gathering.domain.enums.Gender;
+import com.example.wegobe.gathering.domain.Gathering;
+import com.example.wegobe.gathering.domain.HashTag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GatheringListResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String thumbnailUrl;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private LocalDateTime closedAt;
+    private int maxParticipants;
+    private String location;
+
+    private Gender preferredGender;
+    private AgeGroup preferredAge;
+    private Category category;
+
+    private List<String> hashtags;
+
+    private UserInfoResponseDto creator;
+
+    public static GatheringListResponseDto fromEntity(Gathering gathering) {
+        return GatheringListResponseDto.builder()
+                .id(gathering.getId())
+                .title(gathering.getTitle())
+                .content(gathering.getContent())
+                .startAt(gathering.getStartAt())
+                .endAt(gathering.getEndAt())
+                .closedAt(gathering.getClosedAt())
+                .maxParticipants(gathering.getMaxParticipants())
+                .location(gathering.getLocation())
+                .preferredGender(gathering.getPreferredGender())
+                .preferredAge(gathering.getPreferredAge())
+                .category(gathering.getCategory())
+                .thumbnailUrl(gathering.getThumbnailUrl())
+                .hashtags(gathering.getHashtags().stream()
+                        .map(HashTag::getTag)
+                        .collect(Collectors.toList()))
+                .creator(UserInfoResponseDto.builder() // 주최자 정보 변환
+                        .kakaoId(gathering.getCreator().getKakaoId())
+                        .nickname(gathering.getCreator().getNickname())
+                        .email(gathering.getCreator().getEmail())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/dto/response/GatheringResponseDto.java
+++ b/src/main/java/com/example/wegobe/gathering/dto/response/GatheringResponseDto.java
@@ -1,0 +1,64 @@
+package com.example.wegobe.gathering.dto.response;
+
+import com.example.wegobe.auth.dto.response.UserInfoResponseDto;
+import com.example.wegobe.gathering.domain.enums.AgeGroup;
+import com.example.wegobe.gathering.domain.enums.Category;
+import com.example.wegobe.gathering.domain.enums.Gender;
+import com.example.wegobe.gathering.domain.Gathering;
+import com.example.wegobe.gathering.domain.HashTag;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GatheringResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private String thumbnailUrl;
+    private LocalDate startAt;
+    private LocalDate endAt;
+    private LocalDateTime closedAt;
+    private int maxParticipants;
+    private String location;
+
+    private Gender preferredGender;
+    private AgeGroup preferredAge;
+    private Category category;
+
+    private List<String> hashtags;
+
+    private UserInfoResponseDto creator;
+
+    public static GatheringResponseDto fromEntity(Gathering gathering) {
+        return GatheringResponseDto.builder()
+                .id(gathering.getId())
+                .title(gathering.getTitle())
+                .content(gathering.getContent())
+                .startAt(gathering.getStartAt())
+                .endAt(gathering.getEndAt())
+                .closedAt(gathering.getClosedAt())
+                .maxParticipants(gathering.getMaxParticipants())
+                .location(gathering.getLocation())
+                .preferredGender(gathering.getPreferredGender())
+                .preferredAge(gathering.getPreferredAge())
+                .category(gathering.getCategory())
+                .thumbnailUrl(gathering.getThumbnailUrl())
+                .hashtags(gathering.getHashtags().stream()
+                        .map(HashTag::getTag)
+                        .collect(Collectors.toList()))
+                .creator(UserInfoResponseDto.builder() // 주최자 정보 변환
+                        .kakaoId(gathering.getCreator().getKakaoId())
+                        .nickname(gathering.getCreator().getNickname())
+                        .email(gathering.getCreator().getEmail())
+                        .build())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/wegobe/gathering/repository/GatheringRepository.java
+++ b/src/main/java/com/example/wegobe/gathering/repository/GatheringRepository.java
@@ -1,0 +1,7 @@
+package com.example.wegobe.gathering.repository;
+
+import com.example.wegobe.gathering.domain.Gathering;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GatheringRepository extends JpaRepository<Gathering, Long> {
+}

--- a/src/main/java/com/example/wegobe/gathering/service/GatheringService.java
+++ b/src/main/java/com/example/wegobe/gathering/service/GatheringService.java
@@ -1,0 +1,71 @@
+package com.example.wegobe.gathering.service;
+
+import com.example.wegobe.auth.entity.User;
+import com.example.wegobe.auth.repository.UserRepository;
+import com.example.wegobe.config.SecurityUtil;
+import com.example.wegobe.gathering.domain.Gathering;
+import com.example.wegobe.gathering.domain.HashTag;
+import com.example.wegobe.gathering.dto.request.GatheringRequestDto;
+import com.example.wegobe.gathering.repository.GatheringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GatheringService {
+
+    private final GatheringRepository gatheringRepository;
+    private final UserRepository userRepository;
+    private final String DEFAULT_THUMBNAIL_URL = "/resources/picture.jpeg";  // 임시 테스트 이미지
+
+    /**
+     * 모임 생성
+     */
+    @Transactional
+    public Long createGathering(GatheringRequestDto requestDto) {
+
+        Long kakaoId = SecurityUtil.getCurrentKakaoId(); // 유저 정보 조회
+
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+
+        String thumbnailUrl = getThumbnailUrlOrDefault(requestDto.getThumbnailUrl());
+
+        List<HashTag> hashtags = requestDto.getHashtags().stream()
+                .map(tag -> HashTag.builder().tag(tag).build())
+                .collect(Collectors.toList());
+
+        Gathering gathering = Gathering.builder()
+                .creator(user)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .startAt(requestDto.getStartAt())
+                .endAt(requestDto.getEndAt())
+                .closedAt(requestDto.getClosedAt())
+                .location(requestDto.getAddress())
+                .maxParticipants(requestDto.getMaxParticipants())
+                .thumbnailUrl(thumbnailUrl)
+                .preferredAge(requestDto.getPreferredAgeGroup())
+                .preferredGender(requestDto.getPreferredGender())
+                .category(requestDto.getCategory())
+                .hashtags(hashtags)
+                .build();
+
+        gatheringRepository.save(gathering);
+        return gathering.getId();
+    }
+
+    /**
+     * 썸네일이 없을 경우 기본 이미지 URL 반환
+     * 이미지 생성되면 해당 이미지 URL로 변환 예정
+      */
+    private String getThumbnailUrlOrDefault(String thumbnailUrl) {
+        return (thumbnailUrl != null && !thumbnailUrl.isEmpty()) ? thumbnailUrl : DEFAULT_THUMBNAIL_URL;
+    }
+
+}
+

--- a/src/main/java/com/example/wegobe/gathering/service/GatheringService.java
+++ b/src/main/java/com/example/wegobe/gathering/service/GatheringService.java
@@ -6,8 +6,14 @@ import com.example.wegobe.config.SecurityUtil;
 import com.example.wegobe.gathering.domain.Gathering;
 import com.example.wegobe.gathering.domain.HashTag;
 import com.example.wegobe.gathering.dto.request.GatheringRequestDto;
+import com.example.wegobe.gathering.dto.response.GatheringListResponseDto;
+import com.example.wegobe.gathering.dto.response.GatheringResponseDto;
 import com.example.wegobe.gathering.repository.GatheringRepository;
+import com.example.wegobe.global.paging.PageableService;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class GatheringService {
+public class GatheringService implements PageableService<Gathering, GatheringListResponseDto> {
 
     private final GatheringRepository gatheringRepository;
     private final UserRepository userRepository;
@@ -60,12 +66,31 @@ public class GatheringService {
     }
 
     /**
+     * 모임 단일 조회
+     */
+    @Transactional
+    public GatheringResponseDto getGatheringById(Long id) {
+        Gathering gathering = gatheringRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Gathering not found"));
+
+        return GatheringResponseDto.fromEntity(gathering);
+    }
+
+    /**
+     * 모든 모임 목록 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<GatheringListResponseDto> findAll(Pageable pageable) {
+        return gatheringRepository.findAll(pageable)
+                .map(GatheringListResponseDto::fromEntity);
+    }
+
+    /**
      * 썸네일이 없을 경우 기본 이미지 URL 반환
      * 이미지 생성되면 해당 이미지 URL로 변환 예정
-      */
+     */
     private String getThumbnailUrlOrDefault(String thumbnailUrl) {
         return (thumbnailUrl != null && !thumbnailUrl.isEmpty()) ? thumbnailUrl : DEFAULT_THUMBNAIL_URL;
     }
-
 }
-

--- a/src/main/java/com/example/wegobe/global/BaseTimeEntity.java
+++ b/src/main/java/com/example/wegobe/global/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.example.wegobe.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/example/wegobe/global/paging/PageableService.java
+++ b/src/main/java/com/example/wegobe/global/paging/PageableService.java
@@ -1,0 +1,14 @@
+package com.example.wegobe.global.paging;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 공통 페이징 인터페이스
+ * @param <T> Entity
+ * @param <R> 응답 DTO
+ * JPA의 Pageable 사용하여 페이징 처리
+ */
+public interface PageableService<T, R>{
+    Page<R> findAll(Pageable pageable);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 동행 관련 API https://github.com/Wego-A-Journey-Together/Wego-BE/issues/6

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 로그인한 유저 정보를 받아옵니다.
2. 유저 정보와 함께 동행을 등록, 수정할 수 있습니다.
3. 동행 상세 조회 및 동행 전체 목록 조회를 할 수 있습니다.
4. 동행 조회 시, 현재 유저의 정보를 함께 조회할 수 있습니다.
    - 추후에 유저 정보(profileImage , 상태메세지 등)으로 변경이 필요합니다.

5. 동행을 삭제할 수 있습니다.
6. 페이징 인터페이스를 구현했습니다.
    -  기본 페이지 0, 크기 10, 최신순
    - 클라이언트는 특정 페이지 및 크기를 지정할 수 있습니다.
 7. BaseTimeEntity 구현하여, 동행 등록 및 수정 시간은 자동으로 변경됩니다.

### 스크린샷 (선택)
![스크린샷 2025-03-28 00 39 58](https://github.com/user-attachments/assets/6a344ad1-3bdd-4398-93f0-5fe74f62ba19)
![스크린샷 2025-03-28 00 40 24](https://github.com/user-attachments/assets/f3107bbe-9eaa-43ca-9c7d-786d9670462c)
![스크린샷 2025-03-28 00 41 10](https://github.com/user-attachments/assets/800443c7-d50b-4996-add3-85d14117adac)
<img width="731" alt="스크린샷 2025-03-28 02 09 12" src="https://github.com/user-attachments/assets/8d5cbb40-212d-4e34-baa6-3410b4e9c0b3" />
<img width="602" alt="스크린샷 2025-03-28 02 10 08" src="https://github.com/user-attachments/assets/692087e9-f64e-4564-ac66-d6cb92aab33e" />

## 코멘트 💬

> 
> 동행 등록 시 연령대도 enumType 단일 선택으로 구현해놓은 상태인데, 
중복 선택 구현 방향을 좀 더 고민해봐야할 거 같습니다!
동행 등록 시 주소(위경도) 부분때문에 동행 API 2차 수정이 무조건 필요한 상황이라 연령대 중복 선택도 2차 수정에 함께 포함하겠습니다.!!