### PR TITLE
Feature/issue 13

### DIFF
--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
@@ -1,11 +1,14 @@
 package com.example.wegobe.gathering.controller;
 
 import com.example.wegobe.config.SecurityUtil;
+import com.example.wegobe.gathering.dto.response.GatheringMemberResponseDto;
 import com.example.wegobe.gathering.service.GatheringMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -56,6 +59,22 @@ public class GatheringMemberController {
         gatheringMemberService.cancelParticipator(gatheringId, userId, kakaoId);
         return ResponseEntity.ok("동행 참여를 취소하였습니다.");
     }
+    /**
+     * 해당 동행의 신청된 유저들 목록 조회
+     */
+    @GetMapping("/appliers/{gatheringId}")
+    public ResponseEntity<List<GatheringMemberResponseDto>> getAppliers(@PathVariable Long gatheringId) {
 
+        Long kakaoId = SecurityUtil.getCurrentKakaoId();
+        return ResponseEntity.ok(gatheringMemberService.getAppliersList(gatheringId, kakaoId));
+    }
 
+    /**
+     * 특정 동행에 참여중인 유저들 목록 조회
+     */
+    @GetMapping("/participants/{gatheringId}")
+    public ResponseEntity<List<GatheringMemberResponseDto>> getParticipants(@PathVariable Long gatheringId) {
+
+        return ResponseEntity.ok(gatheringMemberService.getParticipantsList(gatheringId));
+    }
 }

--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
@@ -37,4 +37,25 @@ public class GatheringMemberController {
         gatheringMemberService.cancelApplying(gatheringId, kakaoId);
         return ResponseEntity.ok("동행 신청이 취소되었습니다.");
     }
+    /**
+     * 동행 신청 수락
+     */
+    @PatchMapping("/{gatheringId}/accept/{userId}")
+    public ResponseEntity<String> acceptApplication(@PathVariable Long gatheringId, @PathVariable Long userId) {
+        Long kakaoId = SecurityUtil.getCurrentKakaoId();
+        gatheringMemberService.acceptApply(gatheringId, userId, kakaoId);
+        return ResponseEntity.ok("동행 신청을 수락하였습니다.");
+    }
+
+    /**
+     * 수락된 동행 취소 (수락 철회)
+     */
+    @PatchMapping("/{gatheringId}/block/{userId}")
+    public ResponseEntity<String> cancelAcceptedApplication(@PathVariable Long gatheringId, @PathVariable Long userId) {
+        Long kakaoId = SecurityUtil.getCurrentKakaoId();
+        gatheringMemberService.cancelParticipator(gatheringId, userId, kakaoId);
+        return ResponseEntity.ok("동행 참여를 취소하였습니다.");
+    }
+
+
 }

--- a/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
+++ b/src/main/java/com/example/wegobe/gathering/controller/GatheringMemberController.java
@@ -1,0 +1,40 @@
+package com.example.wegobe.gathering.controller;
+
+import com.example.wegobe.config.SecurityUtil;
+import com.example.wegobe.gathering.service.GatheringMemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/gatherings")
+@RequiredArgsConstructor
+public class GatheringMemberController {
+    private final GatheringMemberService gatheringMemberService;
+
+    /**
+     * 동행 참여 신청
+     */
+    @PostMapping("/apply/{gatheringId}")
+    public ResponseEntity<String> apply(@PathVariable("gatheringId") Long gatheringId) {
+        Long kakaoId = SecurityUtil.getCurrentKakaoId();
+        try {
+            gatheringMemberService.applyGathering(gatheringId, kakaoId);
+            return ResponseEntity.status(HttpStatus.CREATED).body("동행 신청이 완료되었습니다.");
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    /**
+     * 동행 신청 취소
+     */
+    @DeleteMapping("/cancel/{gatheringId}/")
+    public ResponseEntity<String> cancelApply(@PathVariable Long gatheringId) {
+        Long kakaoId = SecurityUtil.getCurrentKakaoId();
+        gatheringMemberService.cancelApplying(gatheringId, kakaoId);
+        return ResponseEntity.ok("동행 신청이 취소되었습니다.");
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/GatheringMember.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/GatheringMember.java
@@ -1,0 +1,36 @@
+package com.example.wegobe.gathering.domain;
+
+import com.example.wegobe.auth.entity.User;
+import com.example.wegobe.gathering.domain.enums.GatheringStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GatheringMember {
+
+    @Id
+    @Column(name = "gathering_member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "gathering_id", nullable = false)
+    private Gathering gathering;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GatheringStatus status;
+
+    @Builder
+    public GatheringMember(User user, Gathering gathering, GatheringStatus status) {
+        this.user = user;
+        this.gathering = gathering;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/domain/GatheringMember.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/GatheringMember.java
@@ -33,4 +33,12 @@ public class GatheringMember {
         this.gathering = gathering;
         this.status = status;
     }
+    // 신청 수락
+    public void accept() {
+        this.status = GatheringStatus.ACCEPTED;
+    }
+    // 수락 취소
+    public void cancelByHost() {
+        this.status = GatheringStatus.BLOCKED;
+    }
 }

--- a/src/main/java/com/example/wegobe/gathering/domain/enums/GatheringStatus.java
+++ b/src/main/java/com/example/wegobe/gathering/domain/enums/GatheringStatus.java
@@ -1,0 +1,12 @@
+package com.example.wegobe.gathering.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GatheringStatus {
+    APPLYING,
+    BLOCKED,
+    ACCEPTED,
+}

--- a/src/main/java/com/example/wegobe/gathering/dto/response/GatheringMemberResponseDto.java
+++ b/src/main/java/com/example/wegobe/gathering/dto/response/GatheringMemberResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.wegobe.gathering.dto.response;
+
+import com.example.wegobe.gathering.domain.GatheringMember;
+import com.example.wegobe.gathering.domain.enums.GatheringStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 동행 참여 신청되어있는 유저 목록 조회에서 사용
+ * 유저 프로필 생성되었을 경우 필드 추가 혹은 프로필 response로 변경될 수 있음
+ */
+@Getter
+@Builder
+public class GatheringMemberResponseDto {
+    private Long userId;
+    private String nickname;
+    private GatheringStatus status;
+
+    public static GatheringMemberResponseDto fromEntity(GatheringMember member) {
+        return GatheringMemberResponseDto.builder()
+                .userId(member.getUser().getId())
+                .nickname(member.getUser().getNickname())
+                .status(member.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/wegobe/gathering/repository/GatheringMemberRepository.java
+++ b/src/main/java/com/example/wegobe/gathering/repository/GatheringMemberRepository.java
@@ -1,0 +1,13 @@
+package com.example.wegobe.gathering.repository;
+
+import com.example.wegobe.auth.entity.User;
+import com.example.wegobe.gathering.domain.Gathering;
+import com.example.wegobe.gathering.domain.GatheringMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GatheringMemberRepository extends JpaRepository<GatheringMember, Long> {
+    Optional<GatheringMember> findByUserAndGathering(User user, Gathering gathering);
+
+}

--- a/src/main/java/com/example/wegobe/gathering/repository/GatheringMemberRepository.java
+++ b/src/main/java/com/example/wegobe/gathering/repository/GatheringMemberRepository.java
@@ -3,11 +3,16 @@ package com.example.wegobe.gathering.repository;
 import com.example.wegobe.auth.entity.User;
 import com.example.wegobe.gathering.domain.Gathering;
 import com.example.wegobe.gathering.domain.GatheringMember;
+import com.example.wegobe.gathering.domain.enums.GatheringStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GatheringMemberRepository extends JpaRepository<GatheringMember, Long> {
     Optional<GatheringMember> findByUserAndGathering(User user, Gathering gathering);
 
+    List<GatheringMember> findByGathering(Gathering gathering);
+
+    List<GatheringMember> findByGatheringAndStatus(Gathering gathering, GatheringStatus gatheringStatus);
 }

--- a/src/main/java/com/example/wegobe/gathering/service/GatheringMemberService.java
+++ b/src/main/java/com/example/wegobe/gathering/service/GatheringMemberService.java
@@ -5,13 +5,16 @@ import com.example.wegobe.auth.repository.UserRepository;
 import com.example.wegobe.gathering.domain.Gathering;
 import com.example.wegobe.gathering.domain.GatheringMember;
 import com.example.wegobe.gathering.domain.enums.GatheringStatus;
+import com.example.wegobe.gathering.dto.response.GatheringMemberResponseDto;
 import com.example.wegobe.gathering.repository.GatheringMemberRepository;
 import com.example.wegobe.gathering.repository.GatheringRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -97,7 +100,29 @@ public class GatheringMemberService {
         gatheringMember.cancelByHost();
 
     }
+    // 주최자가 동행 신청한 유저 목록 조회
+    public List<GatheringMemberResponseDto> getAppliersList(Long gatheringId, Long kakaoId) {
 
+        User host = getUserByKakaoId(kakaoId);
+        Gathering gathering = getGatheringById(gatheringId);
+
+        validateHost(gathering, host);
+
+        return gatheringMemberRepository.findByGathering(gathering)
+                .stream()
+                .map(GatheringMemberResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    // 특정 동행에 참여 확정된 유저 조회 (수락된 유저들 목록)
+    public List<GatheringMemberResponseDto> getParticipantsList(Long gatheringId) {
+        Gathering gathering = getGatheringById(gatheringId);
+
+        return gatheringMemberRepository.findByGatheringAndStatus(gathering, GatheringStatus.ACCEPTED)
+                .stream()
+                .map(GatheringMemberResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
 
 
     /**

--- a/src/main/java/com/example/wegobe/gathering/service/GatheringMemberService.java
+++ b/src/main/java/com/example/wegobe/gathering/service/GatheringMemberService.java
@@ -1,0 +1,91 @@
+package com.example.wegobe.gathering.service;
+
+import com.example.wegobe.auth.entity.User;
+import com.example.wegobe.auth.repository.UserRepository;
+import com.example.wegobe.gathering.domain.Gathering;
+import com.example.wegobe.gathering.domain.GatheringMember;
+import com.example.wegobe.gathering.domain.enums.GatheringStatus;
+import com.example.wegobe.gathering.repository.GatheringMemberRepository;
+import com.example.wegobe.gathering.repository.GatheringRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GatheringMemberService {
+
+    private final GatheringMemberRepository gatheringMemberRepository;
+    private final UserRepository userRepository;
+    private final GatheringRepository gatheringRepository;
+
+    // 동행 참여 신청
+    public void applyGathering(Long gatheringId, Long kakaoId) {
+        // 1. 유저 정보 조회
+        User user = getUserByKakaoId(kakaoId);
+        // 2. 동행 아이디로 동행 조회
+        Gathering gathering = getGatheringById(gatheringId);
+
+        // 3.동행 참여 신청 내역 확인
+        Optional<GatheringMember> existing = gatheringMemberRepository.findByUserAndGathering(user, gathering);
+        if (existing.isPresent()) {
+
+            GatheringMember participant = existing.get();
+            GatheringStatus currentStatus = participant.getStatus();
+
+            if (currentStatus == GatheringStatus.APPLYING || currentStatus == GatheringStatus.ACCEPTED) {
+                throw new IllegalStateException("이미 신청한 동행입니다.");
+            }
+            if (currentStatus == GatheringStatus.BLOCKED) {
+                throw new IllegalStateException("해당 동행을 신청할 수 없습니다.");
+            }
+        }
+        // 4. 동행 신청
+        GatheringMember gatheringMember = GatheringMember.builder()
+                .user(user)
+                .gathering(gathering)
+                .status(GatheringStatus.APPLYING)
+                .build();
+
+        gatheringMemberRepository.save(gatheringMember);
+    }
+
+
+    // 동행 참여 신청 취소
+    public void cancelApplying(Long gatheringId, Long kakaoId) {
+        User user = getUserByKakaoId(kakaoId);
+        Gathering gathering = getGatheringById(gatheringId);
+
+        // 동행 참여 신청 내역 확인
+        GatheringMember gatheringMember = getMember(user, gathering);
+
+        gatheringMemberRepository.delete(gatheringMember);
+    }
+
+
+
+
+    /**
+     * 유틸 메서드 분리
+     */
+    // 사용자 인증 정보 조회
+    private User getUserByKakaoId(Long kakaoId) {
+        return userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new RuntimeException("인증된 사용자가 아닙니다."));
+    }
+
+    // 동행 정보 조회
+    private Gathering getGatheringById(Long gatheringId) {
+        return gatheringRepository.findById(gatheringId)
+                .orElseThrow(() -> new RuntimeException("해당 동행을 찾을 수 없습니다."));
+    }
+
+    // 유저의 신청 기록 조회
+    private GatheringMember getMember(User user, Gathering gathering) {
+        return gatheringMemberRepository.findByUserAndGathering(user, gathering)
+                .orElseThrow(() -> new RuntimeException("신청 기록이 없습니다."));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 동행 참여 API  #13

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
>  1. 사용자들은 인증 정보를 통해 동행 참여를 신청 / 신청 취소 할 수 있습니다.
> 2. 주최자는 동행 참여 신청에 대해 승인할 수 있습니다.
> 3. 주최자는 승인했던 동행 참여를 취소할 수 있습니다.
> -> 이 경우, 승인 후 취소된 것이므로, BLOCK 처리 되어 해당 동행에 재신청이 불가능합니다.
> 4. 주최자는  동행에 대해 신청되어있는 유저들의 목록을 조회할 수 있습니다.
> 5. 특정 동행에 참여중인 유저들의 목록을 조회할 수 있습니다.

1. GatheringMember 엔티티 구현
2. GatheringStatus EnumType으로 참여 신청 상태 관리
     APPLYING(신청), ACCEPTED(승인), BLOCKED(제한)
3. 유저가 신청 취소 후 재신청은 가능하지만, 제한될 경우 재신청 불가능하도록 조건 구현
4. 이미 신청된 동행일 경우, 신청 불가 조건 구현
5. 현재 유저들의 목록 조회되는 response는 추후 프로필 생성 후 변경 필요

### 스크린샷 (선택)
![스크린샷 2025-03-29 21 21 05](https://github.com/user-attachments/assets/dbae1807-c1a1-4dae-9276-0ca740382c43)
![스크린샷 2025-03-29 21 21 26](https://github.com/user-attachments/assets/72ad5abc-bf5b-4dc4-8697-7cf428370fa9)
![스크린샷 2025-03-29 21 22 26](https://github.com/user-attachments/assets/d371fc0b-8e52-4c55-87a8-e9d4db42fe6f)
![스크린샷 2025-03-29 21 24 01](https://github.com/user-attachments/assets/e0897170-93a9-4665-b43a-fce8cee36220)
![스크린샷 2025-03-29 21 22 55](https://github.com/user-attachments/assets/5d85f471-5b22-4b91-84d2-80f7a5b7a174)
![스크린샷 2025-03-29 21 23 24](https://github.com/user-attachments/assets/38ea1de7-65b9-4cd2-9286-f9fed6d4aca0)
![스크린샷 2025-03-29 21 25 01](https://github.com/user-attachments/assets/6e084ffc-da16-4785-bf2d-10eb6226f73f)
![스크린샷 2025-03-29 21 25 25](https://github.com/user-attachments/assets/31e3a0f6-3417-4ec4-9129-cdd6f2bd8812)

## 💬리뷰 요구사항(선택)

> 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 조회되는 부분에서 페이징 처리는 일단 제외해두었습니다-!
